### PR TITLE
Permit setting local version in Transport opts

### DIFF
--- a/lib/hrr_rb_ssh/transport.rb
+++ b/lib/hrr_rb_ssh/transport.rb
@@ -67,7 +67,7 @@ module HrrRbSsh
       @sender_monitor   = Monitor.new
       @receiver_monitor = Monitor.new
 
-      @local_version  = "SSH-2.0-HrrRbSsh-#{VERSION}".force_encoding(Encoding::ASCII_8BIT)
+      @local_version  = @options.delete('local_version') || "SSH-2.0-HrrRbSsh-#{VERSION}".force_encoding(Encoding::ASCII_8BIT)
       @remote_version = "".force_encoding(Encoding::ASCII_8BIT)
 
       @incoming_sequence_number = SequenceNumber.new


### PR DESCRIPTION
Permit pulling 'local_version' key from options passed to the
initializer for Transport. Retain backwards compatibility by use
of #delete on the options hash to prevent pollution during later
access and setting the prior string when the key doesn't exist
(returns nil).