### PR TITLE
Feature/sharing variables among authenticators and channel request handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ The `context` variable in password authentication context provides the following
 
 - `#username` : The username that a remote user tries to authenticate
 - `#password` : The password that a remote user tries to authenticate
+- `#variables` : A hash instance that is shared in each authenticator and subsequent session channel request handlers
+- `#vars` : The same object that `#variables` returns
 - `#verify(username, password)` : Returns `true` when username and password arguments match with the context's username and password. Or returns `false` when username and password arguments don't match.
 
 ##### Publickey authentication
@@ -277,6 +279,8 @@ In `HrrRbSsh::Connection::RequestHandler.new` block, context variable basically 
 - `#io => [in, out, err]` : `in` is readable and read data is sent by remote. `out` and `err` are writable. `out` is for standard output and written data is sent as channel data. `err` is for standard error and written data is sent as channel extended data.
 - `#chain_proc => {|chain| ... }` : When a session channel is opened, a background thread is started and is waitng for a chained block registered. This `#chain_proc` is used to define how to handle subsequent communications between local and remote. The `chain` variable provides `#call_next` method. In `#proc_chain` block, it is possible to call subsequent block that is defined in another request handler. For instance, shell request must called after pty-req request. The `chain` in pty-req request handler's `#chain_proc` calls `#next_proc` and then subsequent shell request handler's `#chain_proc` will be called.
 - `#close_session` : In most cases, input and output between a client and the server is handled in `#chain_proc` and closing the `#chain_proc` block will lead closing the underlying session channel. This means that to close the underlying session channel it is required to write at least one `#chain_proc` block. If it is not required to use `#chain_proc` block or is required to close the underlying session channel from outside of `#chain_proc` block, `#close_session` can be used. The `#close_session` will close the background thread that calls `#chain_proc` blocks.
+- `#variables => Hash` : A hash instance that is passed from authenticator and is shared in subsequent session channel request handlers
+- `#vars` : The same object that `#variables` returns
 
 And request handler's `context` variable also provides additional methods based on request type. See `lib/hrr_rb_ssh/connection/channel/channel_type/session/request_type/<request type>/context.rb`.
 

--- a/lib/hrr_rb_ssh/authentication.rb
+++ b/lib/hrr_rb_ssh/authentication.rb
@@ -22,6 +22,7 @@ module HrrRbSsh
       @closed = nil
 
       @username = nil
+      @variables = {}
     end
 
     def send payload
@@ -62,6 +63,11 @@ module HrrRbSsh
       @username
     end
 
+    def variables
+      raise Error::ClosedAuthentication if @closed
+      @variables
+    end
+
     def authenticate
       loop do
         payload = @transport.receive
@@ -69,7 +75,7 @@ module HrrRbSsh
         when Message::SSH_MSG_USERAUTH_REQUEST::VALUE
           userauth_request_message = Message::SSH_MSG_USERAUTH_REQUEST.decode payload
           method_name = userauth_request_message[:'method name']
-          method = Method[method_name].new(@transport, {'session id' => @transport.session_id}.merge(@options))
+          method = Method[method_name].new(@transport, {'session id' => @transport.session_id}.merge(@options), @variables)
           result = method.authenticate(userauth_request_message)
           case result
           when TrueClass

--- a/lib/hrr_rb_ssh/authentication/method/keyboard_interactive.rb
+++ b/lib/hrr_rb_ssh/authentication/method/keyboard_interactive.rb
@@ -10,10 +10,11 @@ module HrrRbSsh
         NAME = 'keyboard-interactive'
         PREFERENCE = 30
 
-        def initialize transport, options
+        def initialize transport, options, variables
           @logger = Logger.new(self.class.name)
           @transport = transport
           @authenticator = options.fetch( 'authentication_keyboard_interactive_authenticator', Authenticator.new { false } )
+          @variables = variables
         end
 
         def authenticate userauth_request_message
@@ -21,7 +22,7 @@ module HrrRbSsh
           @logger.debug { "userauth request: " + userauth_request_message.inspect }
           username = userauth_request_message[:'user name']
           submethods = userauth_request_message[:'submethods']
-          context = Context.new(@transport, username, submethods)
+          context = Context.new(@transport, username, submethods, @variables)
           @authenticator.authenticate context
         end
       end

--- a/lib/hrr_rb_ssh/authentication/method/keyboard_interactive/context.rb
+++ b/lib/hrr_rb_ssh/authentication/method/keyboard_interactive/context.rb
@@ -13,12 +13,16 @@ module HrrRbSsh
           attr_reader \
             :username,
             :submethods,
-            :info_response
+            :info_response,
+            :variables,
+            :vars
 
-          def initialize transport, username, submethods
+          def initialize transport, username, submethods, variables
             @transport = transport
             @username = username
             @submethods = submethods
+            @variables = variables
+            @vars = variables
 
             @logger = Logger.new self.class.name
           end

--- a/lib/hrr_rb_ssh/authentication/method/none.rb
+++ b/lib/hrr_rb_ssh/authentication/method/none.rb
@@ -10,15 +10,16 @@ module HrrRbSsh
         NAME = 'none'
         PREFERENCE = 0
 
-        def initialize transport, options
+        def initialize transport, options, variables
           @logger = Logger.new(self.class.name)
           @authenticator = options.fetch( 'authentication_none_authenticator', Authenticator.new { false } )
+          @variables = variables
         end
 
         def authenticate userauth_request_message
           @logger.info { "authenticate" }
           @logger.debug { "userauth request: " + userauth_request_message.inspect }
-          context = Context.new(userauth_request_message[:'user name'])
+          context = Context.new(userauth_request_message[:'user name'], @variables)
           @authenticator.authenticate context
         end
       end

--- a/lib/hrr_rb_ssh/authentication/method/none/context.rb
+++ b/lib/hrr_rb_ssh/authentication/method/none/context.rb
@@ -8,10 +8,15 @@ module HrrRbSsh
     class Method
       class None
         class Context
-          attr_reader :username
+          attr_reader \
+            :username,
+            :variables,
+            :vars
 
-          def initialize username
+          def initialize username, variables
             @username = username
+            @variables = variables
+            @vars = variables
 
             @logger = Logger.new self.class.name
           end

--- a/lib/hrr_rb_ssh/authentication/method/password.rb
+++ b/lib/hrr_rb_ssh/authentication/method/password.rb
@@ -10,9 +10,10 @@ module HrrRbSsh
         NAME = 'password'
         PREFERENCE = 10
 
-        def initialize transport, options
+        def initialize transport, options, variables
           @logger = Logger.new(self.class.name)
           @authenticator = options.fetch( 'authentication_password_authenticator', Authenticator.new { false } )
+          @variables = variables
         end
 
         def authenticate userauth_request_message
@@ -20,7 +21,7 @@ module HrrRbSsh
           @logger.debug { "userauth request: " + userauth_request_message.inspect }
           username = userauth_request_message[:'user name']
           password = userauth_request_message[:'plaintext password']
-          context = Context.new(username, password)
+          context = Context.new(username, password, @variables)
           @authenticator.authenticate context
         end
       end

--- a/lib/hrr_rb_ssh/authentication/method/password/context.rb
+++ b/lib/hrr_rb_ssh/authentication/method/password/context.rb
@@ -8,11 +8,17 @@ module HrrRbSsh
     class Method
       class Password
         class Context
-          attr_reader :username, :password
+          attr_reader \
+            :username,
+            :password,
+            :variables,
+            :vars
 
-          def initialize username, password
+          def initialize username, password, variables
             @username = username
             @password = password
+            @variables = variables
+            @vars = variables
 
             @logger = Logger.new self.class.name
           end

--- a/lib/hrr_rb_ssh/authentication/method/publickey.rb
+++ b/lib/hrr_rb_ssh/authentication/method/publickey.rb
@@ -10,10 +10,11 @@ module HrrRbSsh
         NAME = 'publickey'
         PREFERENCE = 20
 
-        def initialize transport, options
+        def initialize transport, options, variables
           @logger = Logger.new(self.class.name)
           @session_id = options['session id']
           @authenticator = options.fetch( 'authentication_publickey_authenticator', Authenticator.new { false } )
+          @variables = variables
         end
 
         def authenticate userauth_request_message
@@ -30,7 +31,7 @@ module HrrRbSsh
             @logger.info { "verify signature" }
             username = userauth_request_message[:'user name']
             algorithm = Algorithm[public_key_algorithm_name].new
-            context = Context.new(username, algorithm, @session_id, userauth_request_message)
+            context = Context.new(username, algorithm, @session_id, userauth_request_message, @variables)
             @authenticator.authenticate context
           end
         end

--- a/lib/hrr_rb_ssh/authentication/method/publickey/context.rb
+++ b/lib/hrr_rb_ssh/authentication/method/publickey/context.rb
@@ -11,6 +11,8 @@ module HrrRbSsh
           attr_reader \
             :username,
             :session_id,
+            :variables,
+            :vars,
             :message_number,
             :service_name,
             :method_name,
@@ -19,11 +21,13 @@ module HrrRbSsh
             :public_key_blob,
             :signature
 
-          def initialize username, algorithm, session_id, message
+          def initialize username, algorithm, session_id, message, variables
             @username   = username
             @algorithm  = algorithm
             @session_id = session_id
             @message    = message
+            @variables  = variables
+            @vars       = variables
 
             @message_number            = message[:'message number']
             @service_name              = message[:'service name']

--- a/lib/hrr_rb_ssh/connection.rb
+++ b/lib/hrr_rb_ssh/connection.rb
@@ -10,6 +10,7 @@ module HrrRbSsh
   class Connection
     attr_reader \
       :username,
+      :variables,
       :options
 
     def initialize authentication, options={}
@@ -21,6 +22,7 @@ module HrrRbSsh
       @global_request_handler = GlobalRequestHandler.new self
       @channels = Hash.new
       @username = nil
+      @variables = nil
       @closed = nil
     end
 
@@ -76,6 +78,7 @@ module HrrRbSsh
           break
         end
         @username ||= @authentication.username
+        @variables ||= @authentication.variables
         case payload[0,1].unpack("C")[0]
         when Message::SSH_MSG_GLOBAL_REQUEST::VALUE
           global_request payload

--- a/lib/hrr_rb_ssh/connection/channel/channel_type/session.rb
+++ b/lib/hrr_rb_ssh/connection/channel/channel_type/session.rb
@@ -14,7 +14,6 @@ module HrrRbSsh
             @logger = Logger.new self.class.name
             @connection = connection
             @channel = channel
-            @variables = {}
             @proc_chain = ProcChain.new
           end
 
@@ -30,7 +29,7 @@ module HrrRbSsh
 
           def request message
             request_type = message[:'request type']
-            RequestType[request_type].run @proc_chain, @connection.username, @channel.io, @variables, message, @connection.options, self
+            RequestType[request_type].run @proc_chain, @connection.username, @channel.io, @connection.variables, message, @connection.options, self
           end
 
           def proc_chain_thread

--- a/spec/hrr_rb_ssh/authentication/method/keyboard_interactive/context_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/keyboard_interactive/context_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe HrrRbSsh::Authentication::Method::KeyboardInteractive::Context do
   let(:context_transport){ double('transport') }
   let(:context_username){ "username" }
   let(:context_submethods){ "submethods" }
-  let(:context){ described_class.new context_transport, context_username, context_submethods }
+  let(:context_variables){ {} }
+  let(:context){ described_class.new context_transport, context_username, context_submethods, context_variables }
 
   describe ".new" do
     it "takes three arguments: transport, username and submethods" do
@@ -22,6 +23,18 @@ RSpec.describe HrrRbSsh::Authentication::Method::KeyboardInteractive::Context do
   describe "#submethods" do
     it "returns \"submethods\"" do
       expect( context.submethods ).to eq context_submethods
+    end
+  end
+
+  describe "#variables" do
+    it "returns \"variables\"" do
+      expect( context.variables ).to be context_variables
+    end
+  end
+
+  describe "#vars" do
+    it "returns \"variables\"" do
+      expect( context.vars ).to be context_variables
     end
   end
 

--- a/spec/hrr_rb_ssh/authentication/method/keyboard_interactive_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/keyboard_interactive_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe HrrRbSsh::Authentication::Method::KeyboardInteractive do
   end           
 
   describe ".new" do
-    it "takes two arguments: transport and options" do
-      expect { described_class.new(transport, {}) }.not_to raise_error
+    it "takes three arguments: transport, options, and variables" do
+      expect { described_class.new(transport, {}, {}) }.not_to raise_error
     end     
   end
 
@@ -33,7 +33,8 @@ RSpec.describe HrrRbSsh::Authentication::Method::KeyboardInteractive do
 
     context "when options does not have 'authentication_keyboard_interactive_authenticator'" do
       let(:options){ {} }
-      let(:keyboard_interactive_method){ described_class.new transport, options }
+      let(:variables){ {} }
+      let(:keyboard_interactive_method){ described_class.new transport, options, variables }
 
       it "returns false" do
         expect( keyboard_interactive_method.authenticate userauth_request_message ).to be false
@@ -41,6 +42,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::KeyboardInteractive do
     end
 
     context "when options has 'authentication_keyboard_interactive_authenticator'" do
+      let(:variables){ {} }
       let(:keyboard_interactive_authenticator){
         HrrRbSsh::Authentication::Authenticator.new { |context|
           user_name        = 'username'
@@ -55,7 +57,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::KeyboardInteractive do
           context.username == user_name && info_response.responses == ['password1', 'password2']
         }
       }
-      let(:keyboard_interactive_method){ described_class.new transport, options }
+      let(:keyboard_interactive_method){ described_class.new transport, options, variables }
       let(:userauth_info_request_message){
         {
           :'message number' => HrrRbSsh::Message::SSH_MSG_USERAUTH_INFO_REQUEST::VALUE,

--- a/spec/hrr_rb_ssh/authentication/method/none/context_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/none/context_spec.rb
@@ -2,24 +2,40 @@
 # vim: et ts=2 sw=2
 
 RSpec.describe HrrRbSsh::Authentication::Method::None::Context do
+  let(:context_username){ 'username' }
+  let(:context_variables){ {} }
+  let(:context){ described_class.new context_username, context_variables }
+
   describe ".new" do
     it "takes one argument: username" do
-      expect { described_class.new "username" }.not_to raise_error
+      expect { context }.not_to raise_error
     end
   end
 
   describe "#username" do
     let(:context_username){ "username" }
-    let(:context){ described_class.new context_username }
+    let(:context){ described_class.new context_username, context_variables }
 
     it "returns \"username\"" do
       expect( context.username ).to eq context_username
     end
   end
 
+  describe "#variables" do
+    it "returns \"variables\"" do
+      expect( context.variables ).to be context_variables
+    end
+  end
+
+  describe "#vars" do
+    it "returns \"variables\"" do
+      expect( context.vars ).to be context_variables
+    end
+  end
+
   describe "#verify" do
     let(:context_username){ "username" }
-    let(:context){ described_class.new context_username }
+    let(:context){ described_class.new context_username, context_variables }
     
     context "with \"username\"" do
       let(:username){ "username" }

--- a/spec/hrr_rb_ssh/authentication/method/none_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/none_spec.rb
@@ -18,12 +18,13 @@ RSpec.describe HrrRbSsh::Authentication::Method::None do
   end
 
   describe ".new" do
-    it "takes two arguments: transport and options" do
-      expect { described_class.new(transport, {}) }.not_to raise_error
+    it "takes three arguments: transport, options, and variables" do
+      expect { described_class.new(transport, {}, {}) }.not_to raise_error
     end
   end
 
   describe "#authenticate" do
+    let(:variables){ {} }
     let(:userauth_request_message){
       {
         :'user name' => "username",
@@ -32,7 +33,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::None do
 
     context "when options does not have 'authentication_none_authenticator'" do
       let(:options){ {} }
-      let(:none_method){ described_class.new transport, options }
+      let(:none_method){ described_class.new transport, options, variables }
 
       it "returns false" do
         expect( none_method.authenticate userauth_request_message ).to be false
@@ -45,7 +46,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::None do
           'authentication_none_authenticator' => HrrRbSsh::Authentication::Authenticator.new { true }
         }
       }
-      let(:none_method){ described_class.new transport, options }
+      let(:none_method){ described_class.new transport, options, variables }
 
       it "returns true" do
         expect( none_method.authenticate userauth_request_message ).to be true
@@ -59,7 +60,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::None do
             'authentication_none_authenticator' => HrrRbSsh::Authentication::Authenticator.new { |context| context.verify "username" }
           }
         }
-        let(:none_method){ described_class.new transport, options }
+        let(:none_method){ described_class.new transport, options, variables }
 
         it "returns true" do
           expect( none_method.authenticate userauth_request_message ).to be true
@@ -72,7 +73,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::None do
             'authentication_none_authenticator' => HrrRbSsh::Authentication::Authenticator.new { |context| context.verify "mismatch" }
           }
         }
-        let(:none_method){ described_class.new transport, options }
+        let(:none_method){ described_class.new transport, options, variables }
 
         it "returns false" do
           expect( none_method.authenticate userauth_request_message ).to be false

--- a/spec/hrr_rb_ssh/authentication/method/password/context_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/password/context_spec.rb
@@ -2,16 +2,21 @@
 # vim: et ts=2 sw=2
 
 RSpec.describe HrrRbSsh::Authentication::Method::Password::Context do
+  let(:context_username){ 'username' }
+  let(:context_password){ 'password' }
+  let(:context_variables){ {} }
+  let(:context){ described_class.new context_username, context_password, context_variables }
+
   describe ".new" do
     it "takes two arguments: username and password" do
-      expect { described_class.new "username", "password" }.not_to raise_error
+      expect { context }.not_to raise_error
     end
   end
 
   describe "#username" do
     let(:context_username){ "username" }
     let(:context_password){ "password" }
-    let(:context){ described_class.new context_username, context_password }
+    let(:context){ described_class.new context_username, context_password, context_variables }
 
     it "returns \"username\"" do
       expect( context.username ).to eq context_username
@@ -21,17 +26,29 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password::Context do
   describe "#password" do
     let(:context_username){ "username" }
     let(:context_password){ "password" }
-    let(:context){ described_class.new context_username, context_password }
+    let(:context){ described_class.new context_username, context_password, context_variables }
 
     it "returns \"password\"" do
       expect( context.password ).to eq context_password
     end
   end
 
+  describe "#variables" do
+    it "returns \"variables\"" do
+      expect( context.variables ).to be context_variables
+    end
+  end
+
+  describe "#vars" do
+    it "returns \"variables\"" do
+      expect( context.vars ).to be context_variables
+    end
+  end
+
   describe "#verify" do
     let(:context_username){ "username" }
     let(:context_password){ "password" }
-    let(:context){ described_class.new context_username, context_password }
+    let(:context){ described_class.new context_username, context_password, context_variables }
     
     context "with \"username\" and \"password\"" do
       let(:username){ "username" }

--- a/spec/hrr_rb_ssh/authentication/method/password_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/password_spec.rb
@@ -18,12 +18,13 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password do
   end           
 
   describe ".new" do
-    it "takes two arguments: transport and options" do
-      expect { described_class.new(transport, {}) }.not_to raise_error
+    it "takes three arguments: transport, options, and variables" do
+      expect { described_class.new(transport, {}, {}) }.not_to raise_error
     end     
   end
 
   describe "#authenticate" do
+    let(:variables){ {} }
     let(:userauth_request_message){
       {
         :'user name'          => "username",
@@ -33,7 +34,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password do
 
     context "when options does not have 'authentication_password_authenticator'" do
       let(:options){ {} }
-      let(:password_method){ described_class.new transport, options }
+      let(:password_method){ described_class.new transport, options, variables }
 
       it "returns false" do
         expect( password_method.authenticate userauth_request_message ).to be false
@@ -46,7 +47,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password do
           'authentication_password_authenticator' => HrrRbSsh::Authentication::Authenticator.new { true }
         }
       }
-      let(:password_method){ described_class.new transport, options }
+      let(:password_method){ described_class.new transport, options, variables }
 
       it "returns true" do
         expect( password_method.authenticate userauth_request_message ).to be true
@@ -60,7 +61,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password do
             'authentication_password_authenticator' => HrrRbSsh::Authentication::Authenticator.new { |context| context.verify "username", "password" }
           }
         }
-        let(:password_method){ described_class.new transport, options }
+        let(:password_method){ described_class.new transport, options, variables }
 
         it "returns true" do
           expect( password_method.authenticate userauth_request_message ).to be true
@@ -73,7 +74,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password do
             'authentication_password_authenticator' => HrrRbSsh::Authentication::Authenticator.new { |context| context.verify "mismatch", "mismatch" }
           }
         }
-        let(:password_method){ described_class.new transport, options }
+        let(:password_method){ described_class.new transport, options, variables }
 
         it "returns false" do
           expect( password_method.authenticate userauth_request_message ).to be false

--- a/spec/hrr_rb_ssh/authentication/method/publickey/context_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/publickey/context_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe HrrRbSsh::Authentication::Method::Publickey::Context do
       :'signature'                 => "signature",
     }
   }
-  let(:context){ described_class.new username, algorithm, session_id, message }
+  let(:context_variables){ {} }
+  let(:context){ described_class.new username, algorithm, session_id, message, context_variables }
 
   describe ".new" do
     it "takes four arguments: username, algorithm, session_id, message" do
@@ -78,6 +79,18 @@ RSpec.describe HrrRbSsh::Authentication::Method::Publickey::Context do
   describe "#signature" do
     it "returns \"signature\"" do
       expect( context.signature ).to eq "signature"
+    end
+  end
+
+  describe "#variables" do
+    it "returns \"variables\"" do
+      expect( context.variables ).to be context_variables
+    end
+  end
+
+  describe "#vars" do
+    it "returns \"variables\"" do
+      expect( context.vars ).to be context_variables
     end
   end
 

--- a/spec/hrr_rb_ssh/authentication/method/publickey_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/publickey_spec.rb
@@ -25,11 +25,12 @@ RSpec.describe HrrRbSsh::Authentication::Method::Publickey do
       'authentication_publickey_authenticator' => authentication_publickey_authenticator,
     }
   }
-  let(:publickey){ described_class.new(transport, options) }
+  let(:variables){ {} }
+  let(:publickey){ described_class.new(transport, options, variables) }
 
   describe ".new" do
-    it "takes two arguments: transport and options" do
-      expect { described_class.new(transport, {}) }.not_to raise_error
+    it "takes three arguments: transport, options, and variables" do
+      expect { described_class.new(transport, {}, {}) }.not_to raise_error
     end     
 
     it "stores @session_id" do


### PR DESCRIPTION
Implemented authenticator's `Context#variables` that is shared among authenticators and channel request handlers (Issue #7).

- Multiple-step authentication

```ruby
auth_publickey = HrrRbSsh::Authentication::Authenticator.new { |context|
  # verify context here with context.verify
  context.vars['auth_pubkey_ok?'] = true
  context.vars.fetch('auth_password_ok?', false) && context.vars.fetch('auth_pubkey_ok?', false)
}
auth_password = HrrRbSsh::Authentication::Authenticator.new { |context|
  # verify context here with context.verify
  context.vars['auth_password_ok?'] = true
  context.vars.fetch('auth_password_ok?', false) && context.vars.fetch('auth_pubkey_ok?', false)
}
```

- Sharing variables among authenticators and channel request handlers

```ruby
auth_password = HrrRbSsh::Authentication::Authenticator.new { |context|
  context.vars['password'] = context.password
  # verify context here with context.verify
}
conn_shell = HrrRbSsh::Connection::RequestHandler.new { |context|
  context.vars['password'] # => password string stored in auth_password 
}
```