### PR TITLE
Feature/multi-step authentication

### DIFF
--- a/demo/multi_step_auth.rb
+++ b/demo/multi_step_auth.rb
@@ -1,0 +1,93 @@
+# coding: utf-8
+# vim: et ts=2 sw=2
+
+require 'logger'
+require 'socket'
+
+
+def start_service io, logger=nil
+  require 'etc'
+
+  begin
+    require 'hrr_rb_ssh'
+  rescue LoadError
+    $:.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+    require 'hrr_rb_ssh'
+  end
+
+  HrrRbSsh::Logger.initialize logger if logger
+
+  auth_publickey = HrrRbSsh::Authentication::Authenticator.new { |context|
+    users = ['user1', 'user2']
+    is_verified = users.any?{ |username|
+      passwd = Etc.getpwnam(username)
+      homedir = passwd.dir
+      authorized_keys = HrrRbSsh::Compat::OpenSSH::AuthorizedKeys.new(File.read(File.join(homedir, '.ssh', 'authorized_keys')))
+      authorized_keys.any?{ |public_key| context.verify username, public_key.algorithm_name, public_key.to_pem }
+    }
+    if is_verified
+      HrrRbSsh::Authentication::PARTIAL_SUCCESS
+    else
+      HrrRbSsh::Authentication::FAILURE
+    end
+  }
+  auth_password = HrrRbSsh::Authentication::Authenticator.new { |context|
+    user_and_pass = [
+      ['user1',  'password1'],
+      ['user2',  'password2'],
+    ]
+    is_verified = user_and_pass.any? { |user, pass| context.verify user, pass }
+    if is_verified
+      HrrRbSsh::Authentication::PARTIAL_SUCCESS
+    else
+      HrrRbSsh::Authentication::FAILURE
+    end
+  }
+
+  auth_preferred_authentication_methods = ["publickey", "password"]
+
+
+  options = {}
+
+  options['authentication_publickey_authenticator'] = auth_publickey
+  options['authentication_password_authenticator']  = auth_password
+
+  options['authentication_preferred_authentication_methods'] = auth_preferred_authentication_methods
+
+  options['connection_channel_request_pty_req']       = HrrRbSsh::Connection::RequestHandler::ReferencePtyReqRequestHandler.new
+  options['connection_channel_request_env']           = HrrRbSsh::Connection::RequestHandler::ReferenceEnvRequestHandler.new
+  options['connection_channel_request_shell']         = HrrRbSsh::Connection::RequestHandler::ReferenceShellRequestHandler.new
+  options['connection_channel_request_exec']          = HrrRbSsh::Connection::RequestHandler::ReferenceExecRequestHandler.new
+  options['connection_channel_request_window_change'] = HrrRbSsh::Connection::RequestHandler::ReferenceWindowChangeRequestHandler.new
+
+  server = HrrRbSsh::Server.new options
+  server.start io
+end
+
+
+logger = Logger.new STDOUT
+logger.level = Logger::INFO
+
+server = TCPServer.new 10022
+loop do
+  Thread.new(server.accept) do |io|
+    begin
+      pid = fork do
+        begin
+          start_service io, logger
+        rescue => e
+          logger.error { [e.backtrace[0], ": ", e.message, " (", e.class.to_s, ")\n\t", e.backtrace[1..-1].join("\n\t")].join }
+          exit false
+        end
+      end
+      logger.info { "process #{pid} started" }
+      io.close rescue nil
+      pid, status = Process.waitpid2 pid
+    rescue => e
+      logger.error { [e.backtrace[0], ": ", e.message, " (", e.class.to_s, ")\n\t", e.backtrace[1..-1].join("\n\t")].join }
+    ensure
+      status ||= nil
+      logger.info { "process #{pid} finished with status #{status.inspect}" }
+    end
+  end
+end

--- a/lib/hrr_rb_ssh/authentication.rb
+++ b/lib/hrr_rb_ssh/authentication.rb
@@ -70,7 +70,7 @@ module HrrRbSsh
     end
 
     def authenticate
-      preferred_authentication_methods = @options['authentication_preferred_authentication_methods'].dup || Method.list_preferred
+      preferred_authentication_methods = (@options['authentication_preferred_authentication_methods'].dup rescue nil) || Method.list_preferred # rescue nil.dup for Ruby version < 2.4
       @logger.info { "preferred authentication methods: #{preferred_authentication_methods}" }
       loop do
         payload = @transport.receive

--- a/lib/hrr_rb_ssh/authentication.rb
+++ b/lib/hrr_rb_ssh/authentication.rb
@@ -4,12 +4,13 @@
 require 'hrr_rb_ssh/logger'
 require 'hrr_rb_ssh/message'
 require 'hrr_rb_ssh/error/closed_authentication'
+require 'hrr_rb_ssh/authentication/constant'
 require 'hrr_rb_ssh/authentication/authenticator'
 require 'hrr_rb_ssh/authentication/method'
 
 module HrrRbSsh
   class Authentication
-    SERVICE_NAME = 'ssh-userauth'
+    include Constant
 
     def initialize transport, options={}
       @transport = transport
@@ -69,27 +70,44 @@ module HrrRbSsh
     end
 
     def authenticate
+      preferred_authentication_methods = @options['authentication_preferred_authentication_methods'].dup || Method.list_preferred
+      @logger.info { "preferred authentication methods: #{preferred_authentication_methods}" }
       loop do
         payload = @transport.receive
         case payload[0,1].unpack("C")[0]
         when Message::SSH_MSG_USERAUTH_REQUEST::VALUE
           userauth_request_message = Message::SSH_MSG_USERAUTH_REQUEST.decode payload
           method_name = userauth_request_message[:'method name']
+          @logger.info { "authentication method: #{method_name}" }
           method = Method[method_name].new(@transport, {'session id' => @transport.session_id}.merge(@options), @variables)
           result = method.authenticate(userauth_request_message)
           case result
-          when TrueClass
+          when true, SUCCESS
             @logger.info { "verified" }
             send_userauth_success
             @username = userauth_request_message[:'user name']
             @closed = false
             break
-          when FalseClass
-            @logger.info { "verify failed" }
-            send_userauth_failure
+          when PARTIAL_SUCCESS
+            @logger.info { "partially verified" }
+            preferred_authentication_methods.delete method_name
+            @logger.debug { "remaining preferred: #{preferred_authentication_methods}" }
+            if preferred_authentication_methods.empty?
+              @logger.info { "verified" }
+              send_userauth_success
+              @username = userauth_request_message[:'user name']
+              @closed = false
+              break
+            else
+              @logger.info { "continue" }
+              send_userauth_failure preferred_authentication_methods, true
+            end
           when String
             @logger.info { "send method specific message to continue" }
             send_method_specific_message result
+          else # when false, FAILURE
+            @logger.info { "verify failed" }
+            send_userauth_failure preferred_authentication_methods, false
           end
         else
           @closed = true
@@ -98,11 +116,11 @@ module HrrRbSsh
       end
     end
 
-    def send_userauth_failure
+    def send_userauth_failure preferred_authentication_methods, partial_success
       message = {
         :'message number'                    => Message::SSH_MSG_USERAUTH_FAILURE::VALUE,
-        :'authentications that can continue' => Method.list_preferred,
-        :'partial success'                   => false,
+        :'authentications that can continue' => preferred_authentication_methods,
+        :'partial success'                   => partial_success,
       }
       payload = Message::SSH_MSG_USERAUTH_FAILURE.encode message
       @transport.send payload

--- a/lib/hrr_rb_ssh/authentication/constant.rb
+++ b/lib/hrr_rb_ssh/authentication/constant.rb
@@ -1,0 +1,14 @@
+# coding: utf-8
+# vim: et ts=2 sw=2
+
+module HrrRbSsh
+  class Authentication
+    module Constant
+      SERVICE_NAME = 'ssh-userauth'
+
+      SUCCESS         = :success
+      PARTIAL_SUCCESS = :partial_success
+      FAILURE         = :failure
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses Issue #10 with implementing flexible preferred authentication method list and partial success response.

Combining authentications, it is possible to implement multi-step authentication. In case that the combination is a publickey authentication method and a password authentication method, it is so-called two-factor authentication.

A return value of each authentication handler can be `HrrRbSsh::Authentication::PARTIAL_SUCCESS`. The value means that the authentication method returns success and another authenticatoin method is requested (i.e. the authentication method is deleted from the list of authentication that can continue, and then the server sends USERAUTH_FAILURE message with the updated list of authentication that can continue and partial success true). When all preferred authentication methods returns `PARTIAL_SUCCESS` (i.e. there is no more authentication that can continue), then the user is treated as authenticated.

```ruby
auth_preferred_authentication_methods = ["publickey", "password"]
auth_publickey = HrrRbSsh::Authentication::Authenticator.new { |context|
  is_verified = some_verification_method(context)
  if is_verified
    HrrRbSsh::Authentication::PARTIAL_SUCCESS
  else
    false
  end
}
auth_password = HrrRbSsh::Authentication::Authenticator.new { |context|
  is_verified = some_verification_method(context)
  if is_verified
    HrrRbSsh::Authentication::PARTIAL_SUCCESS
  else
    false
  end
}
options['authentication_preferred_authentication_methods'] = auth_preferred_authentication_methods
options['authentication_publickey_authenticator'] = auth_publickey
options['authentication_password_authenticator'] = auth_password
```
