### PR TITLE
Feature/authenticator context to support accessing authentication methods that can continue

### DIFF
--- a/demo/more_flexible_auth.rb
+++ b/demo/more_flexible_auth.rb
@@ -1,0 +1,99 @@
+# coding: utf-8
+# vim: et ts=2 sw=2
+
+require 'logger'
+require 'socket'
+
+
+def start_service io, logger=nil
+  require 'etc'
+
+  begin
+    require 'hrr_rb_ssh'
+  rescue LoadError
+    $:.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+    require 'hrr_rb_ssh'
+  end
+
+  HrrRbSsh::Logger.initialize logger if logger
+
+  auth_none = HrrRbSsh::Authentication::Authenticator.new { |context|
+    context.authentication_methods.push 'publickey'
+    HrrRbSsh::Authentication::PARTIAL_SUCCESS
+  }
+  auth_publickey = HrrRbSsh::Authentication::Authenticator.new { |context|
+    users = ['user1', 'user2']
+    is_verified = users.any?{ |username|
+      passwd = Etc.getpwnam(username)
+      homedir = passwd.dir
+      authorized_keys = HrrRbSsh::Compat::OpenSSH::AuthorizedKeys.new(File.read(File.join(homedir, '.ssh', 'authorized_keys')))
+      authorized_keys.any?{ |public_key| context.verify username, public_key.algorithm_name, public_key.to_pem }
+    }
+    if is_verified
+      context.authentication_methods.push 'password'
+      HrrRbSsh::Authentication::PARTIAL_SUCCESS
+    else
+      HrrRbSsh::Authentication::FAILURE
+    end
+  }
+  auth_password = HrrRbSsh::Authentication::Authenticator.new { |context|
+    user_and_pass = [
+      ['user1',  'password1'],
+      ['user2',  'password2'],
+    ]
+    is_verified = user_and_pass.any? { |user, pass| context.verify user, pass }
+    if is_verified
+      HrrRbSsh::Authentication::SUCCESS # or HrrRbSsh::Authentication::PARTIAL_SUCCESS
+    else
+      HrrRbSsh::Authentication::FAILURE
+    end
+  }
+
+  auth_preferred_authentication_methods = ["none"]
+
+
+  options = {}
+
+  options['authentication_none_authenticator']      = auth_none
+  options['authentication_publickey_authenticator'] = auth_publickey
+  options['authentication_password_authenticator']  = auth_password
+
+  options['authentication_preferred_authentication_methods'] = auth_preferred_authentication_methods
+
+  options['connection_channel_request_pty_req']       = HrrRbSsh::Connection::RequestHandler::ReferencePtyReqRequestHandler.new
+  options['connection_channel_request_env']           = HrrRbSsh::Connection::RequestHandler::ReferenceEnvRequestHandler.new
+  options['connection_channel_request_shell']         = HrrRbSsh::Connection::RequestHandler::ReferenceShellRequestHandler.new
+  options['connection_channel_request_exec']          = HrrRbSsh::Connection::RequestHandler::ReferenceExecRequestHandler.new
+  options['connection_channel_request_window_change'] = HrrRbSsh::Connection::RequestHandler::ReferenceWindowChangeRequestHandler.new
+
+  server = HrrRbSsh::Server.new options
+  server.start io
+end
+
+
+logger = Logger.new STDOUT
+logger.level = Logger::INFO
+
+server = TCPServer.new 10022
+loop do
+  Thread.new(server.accept) do |io|
+    begin
+      pid = fork do
+        begin
+          start_service io, logger
+        rescue => e
+          logger.error { [e.backtrace[0], ": ", e.message, " (", e.class.to_s, ")\n\t", e.backtrace[1..-1].join("\n\t")].join }
+          exit false
+        end
+      end
+      logger.info { "process #{pid} started" }
+      io.close rescue nil
+      pid, status = Process.waitpid2 pid
+    rescue => e
+      logger.error { [e.backtrace[0], ": ", e.message, " (", e.class.to_s, ")\n\t", e.backtrace[1..-1].join("\n\t")].join }
+    ensure
+      status ||= nil
+      logger.info { "process #{pid} finished with status #{status.inspect}" }
+    end
+  end
+end

--- a/lib/hrr_rb_ssh/authentication/method/keyboard_interactive.rb
+++ b/lib/hrr_rb_ssh/authentication/method/keyboard_interactive.rb
@@ -10,11 +10,12 @@ module HrrRbSsh
         NAME = 'keyboard-interactive'
         PREFERENCE = 30
 
-        def initialize transport, options, variables
+        def initialize transport, options, variables, authentication_methods
           @logger = Logger.new(self.class.name)
           @transport = transport
           @authenticator = options.fetch( 'authentication_keyboard_interactive_authenticator', Authenticator.new { false } )
           @variables = variables
+          @authentication_methods = authentication_methods
         end
 
         def authenticate userauth_request_message
@@ -22,7 +23,7 @@ module HrrRbSsh
           @logger.debug { "userauth request: " + userauth_request_message.inspect }
           username = userauth_request_message[:'user name']
           submethods = userauth_request_message[:'submethods']
-          context = Context.new(@transport, username, submethods, @variables)
+          context = Context.new(@transport, username, submethods, @variables, @authentication_methods)
           @authenticator.authenticate context
         end
       end

--- a/lib/hrr_rb_ssh/authentication/method/keyboard_interactive/context.rb
+++ b/lib/hrr_rb_ssh/authentication/method/keyboard_interactive/context.rb
@@ -15,14 +15,16 @@ module HrrRbSsh
             :submethods,
             :info_response,
             :variables,
-            :vars
+            :vars,
+            :authentication_methods
 
-          def initialize transport, username, submethods, variables
+          def initialize transport, username, submethods, variables, authentication_methods
             @transport = transport
             @username = username
             @submethods = submethods
             @variables = variables
             @vars = variables
+            @authentication_methods = authentication_methods
 
             @logger = Logger.new self.class.name
           end

--- a/lib/hrr_rb_ssh/authentication/method/none.rb
+++ b/lib/hrr_rb_ssh/authentication/method/none.rb
@@ -10,16 +10,17 @@ module HrrRbSsh
         NAME = 'none'
         PREFERENCE = 0
 
-        def initialize transport, options, variables
+        def initialize transport, options, variables, authentication_methods
           @logger = Logger.new(self.class.name)
           @authenticator = options.fetch( 'authentication_none_authenticator', Authenticator.new { false } )
           @variables = variables
+          @authentication_methods = authentication_methods
         end
 
         def authenticate userauth_request_message
           @logger.info { "authenticate" }
           @logger.debug { "userauth request: " + userauth_request_message.inspect }
-          context = Context.new(userauth_request_message[:'user name'], @variables)
+          context = Context.new(userauth_request_message[:'user name'], @variables, @authentication_methods)
           @authenticator.authenticate context
         end
       end

--- a/lib/hrr_rb_ssh/authentication/method/none/context.rb
+++ b/lib/hrr_rb_ssh/authentication/method/none/context.rb
@@ -11,12 +11,14 @@ module HrrRbSsh
           attr_reader \
             :username,
             :variables,
-            :vars
+            :vars,
+            :authentication_methods
 
-          def initialize username, variables
+          def initialize username, variables, authentication_methods
             @username = username
             @variables = variables
             @vars = variables
+            @authentication_methods = authentication_methods
 
             @logger = Logger.new self.class.name
           end

--- a/lib/hrr_rb_ssh/authentication/method/password.rb
+++ b/lib/hrr_rb_ssh/authentication/method/password.rb
@@ -10,10 +10,11 @@ module HrrRbSsh
         NAME = 'password'
         PREFERENCE = 10
 
-        def initialize transport, options, variables
+        def initialize transport, options, variables, authentication_methods
           @logger = Logger.new(self.class.name)
           @authenticator = options.fetch( 'authentication_password_authenticator', Authenticator.new { false } )
           @variables = variables
+          @authentication_methods = authentication_methods
         end
 
         def authenticate userauth_request_message
@@ -21,7 +22,7 @@ module HrrRbSsh
           @logger.debug { "userauth request: " + userauth_request_message.inspect }
           username = userauth_request_message[:'user name']
           password = userauth_request_message[:'plaintext password']
-          context = Context.new(username, password, @variables)
+          context = Context.new(username, password, @variables, @authentication_methods)
           @authenticator.authenticate context
         end
       end

--- a/lib/hrr_rb_ssh/authentication/method/password/context.rb
+++ b/lib/hrr_rb_ssh/authentication/method/password/context.rb
@@ -12,13 +12,15 @@ module HrrRbSsh
             :username,
             :password,
             :variables,
-            :vars
+            :vars,
+            :authentication_methods
 
-          def initialize username, password, variables
+          def initialize username, password, variables, authentication_methods
             @username = username
             @password = password
             @variables = variables
             @vars = variables
+            @authentication_methods = authentication_methods
 
             @logger = Logger.new self.class.name
           end

--- a/lib/hrr_rb_ssh/authentication/method/publickey.rb
+++ b/lib/hrr_rb_ssh/authentication/method/publickey.rb
@@ -10,11 +10,12 @@ module HrrRbSsh
         NAME = 'publickey'
         PREFERENCE = 20
 
-        def initialize transport, options, variables
+        def initialize transport, options, variables, authentication_methods
           @logger = Logger.new(self.class.name)
           @session_id = options['session id']
           @authenticator = options.fetch( 'authentication_publickey_authenticator', Authenticator.new { false } )
           @variables = variables
+          @authentication_methods = authentication_methods
         end
 
         def authenticate userauth_request_message
@@ -31,7 +32,7 @@ module HrrRbSsh
             @logger.info { "verify signature" }
             username = userauth_request_message[:'user name']
             algorithm = Algorithm[public_key_algorithm_name].new
-            context = Context.new(username, algorithm, @session_id, userauth_request_message, @variables)
+            context = Context.new(username, algorithm, @session_id, userauth_request_message, @variables, @authentication_methods)
             @authenticator.authenticate context
           end
         end

--- a/lib/hrr_rb_ssh/authentication/method/publickey/context.rb
+++ b/lib/hrr_rb_ssh/authentication/method/publickey/context.rb
@@ -13,6 +13,7 @@ module HrrRbSsh
             :session_id,
             :variables,
             :vars,
+            :authentication_methods,
             :message_number,
             :service_name,
             :method_name,
@@ -21,13 +22,14 @@ module HrrRbSsh
             :public_key_blob,
             :signature
 
-          def initialize username, algorithm, session_id, message, variables
+          def initialize username, algorithm, session_id, message, variables, authentication_methods
             @username   = username
             @algorithm  = algorithm
             @session_id = session_id
             @message    = message
             @variables  = variables
             @vars       = variables
+            @authentication_methods = authentication_methods
 
             @message_number            = message[:'message number']
             @service_name              = message[:'service name']

--- a/spec/hrr_rb_ssh/authentication/method/keyboard_interactive/context_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/keyboard_interactive/context_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe HrrRbSsh::Authentication::Method::KeyboardInteractive::Context do
   let(:context_username){ "username" }
   let(:context_submethods){ "submethods" }
   let(:context_variables){ {} }
-  let(:context){ described_class.new context_transport, context_username, context_submethods, context_variables }
+  let(:context_authentication_methods){ [] }
+  let(:context){ described_class.new context_transport, context_username, context_submethods, context_variables, context_authentication_methods }
 
   describe ".new" do
     it "takes three arguments: transport, username and submethods" do
@@ -35,6 +36,12 @@ RSpec.describe HrrRbSsh::Authentication::Method::KeyboardInteractive::Context do
   describe "#vars" do
     it "returns \"variables\"" do
       expect( context.vars ).to be context_variables
+    end
+  end
+
+  describe "#authentication_methods" do
+    it "returns \"authentication_methods\"" do
+      expect( context.authentication_methods ).to be context_authentication_methods
     end
   end
 

--- a/spec/hrr_rb_ssh/authentication/method/keyboard_interactive_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/keyboard_interactive_spec.rb
@@ -18,12 +18,14 @@ RSpec.describe HrrRbSsh::Authentication::Method::KeyboardInteractive do
   end           
 
   describe ".new" do
-    it "takes three arguments: transport, options, and variables" do
-      expect { described_class.new(transport, {}, {}) }.not_to raise_error
+    it "takes three arguments: transport, options, variables, and authentication_methods" do
+      expect { described_class.new(transport, {}, {}, []) }.not_to raise_error
     end     
   end
 
   describe "#authenticate" do
+    let(:variables){ {} }
+    let(:authentication_methods){ [] }
     let(:userauth_request_message){
       {
         :'user name'  => "username",
@@ -33,8 +35,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::KeyboardInteractive do
 
     context "when options does not have 'authentication_keyboard_interactive_authenticator'" do
       let(:options){ {} }
-      let(:variables){ {} }
-      let(:keyboard_interactive_method){ described_class.new transport, options, variables }
+      let(:keyboard_interactive_method){ described_class.new transport, options, variables, authentication_methods }
 
       it "returns false" do
         expect( keyboard_interactive_method.authenticate userauth_request_message ).to be false
@@ -42,7 +43,6 @@ RSpec.describe HrrRbSsh::Authentication::Method::KeyboardInteractive do
     end
 
     context "when options has 'authentication_keyboard_interactive_authenticator'" do
-      let(:variables){ {} }
       let(:keyboard_interactive_authenticator){
         HrrRbSsh::Authentication::Authenticator.new { |context|
           user_name        = 'username'
@@ -57,7 +57,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::KeyboardInteractive do
           context.username == user_name && info_response.responses == ['password1', 'password2']
         }
       }
-      let(:keyboard_interactive_method){ described_class.new transport, options, variables }
+      let(:keyboard_interactive_method){ described_class.new transport, options, variables, authentication_methods }
       let(:userauth_info_request_message){
         {
           :'message number' => HrrRbSsh::Message::SSH_MSG_USERAUTH_INFO_REQUEST::VALUE,

--- a/spec/hrr_rb_ssh/authentication/method/none/context_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/none/context_spec.rb
@@ -4,7 +4,8 @@
 RSpec.describe HrrRbSsh::Authentication::Method::None::Context do
   let(:context_username){ 'username' }
   let(:context_variables){ {} }
-  let(:context){ described_class.new context_username, context_variables }
+  let(:context_authentication_methods){ [] }
+  let(:context){ described_class.new context_username, context_variables, context_authentication_methods }
 
   describe ".new" do
     it "takes one argument: username" do
@@ -14,7 +15,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::None::Context do
 
   describe "#username" do
     let(:context_username){ "username" }
-    let(:context){ described_class.new context_username, context_variables }
+    let(:context){ described_class.new context_username, context_variables, context_authentication_methods }
 
     it "returns \"username\"" do
       expect( context.username ).to eq context_username
@@ -33,9 +34,15 @@ RSpec.describe HrrRbSsh::Authentication::Method::None::Context do
     end
   end
 
+  describe "#authentication_methods" do
+    it "returns \"authentication_methods\"" do
+      expect( context.authentication_methods ).to be context_authentication_methods
+    end
+  end
+
   describe "#verify" do
     let(:context_username){ "username" }
-    let(:context){ described_class.new context_username, context_variables }
+    let(:context){ described_class.new context_username, context_variables, context_authentication_methods }
     
     context "with \"username\"" do
       let(:username){ "username" }

--- a/spec/hrr_rb_ssh/authentication/method/none_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/none_spec.rb
@@ -18,13 +18,14 @@ RSpec.describe HrrRbSsh::Authentication::Method::None do
   end
 
   describe ".new" do
-    it "takes three arguments: transport, options, and variables" do
-      expect { described_class.new(transport, {}, {}) }.not_to raise_error
+    it "takes three arguments: transport, options, variables, and authentication_methods" do
+      expect { described_class.new(transport, {}, {}, []) }.not_to raise_error
     end
   end
 
   describe "#authenticate" do
     let(:variables){ {} }
+    let(:authentication_methods){ [] }
     let(:userauth_request_message){
       {
         :'user name' => "username",
@@ -33,7 +34,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::None do
 
     context "when options does not have 'authentication_none_authenticator'" do
       let(:options){ {} }
-      let(:none_method){ described_class.new transport, options, variables }
+      let(:none_method){ described_class.new transport, options, variables, authentication_methods }
 
       it "returns false" do
         expect( none_method.authenticate userauth_request_message ).to be false
@@ -46,7 +47,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::None do
           'authentication_none_authenticator' => HrrRbSsh::Authentication::Authenticator.new { true }
         }
       }
-      let(:none_method){ described_class.new transport, options, variables }
+      let(:none_method){ described_class.new transport, options, variables, authentication_methods }
 
       it "returns true" do
         expect( none_method.authenticate userauth_request_message ).to be true
@@ -60,7 +61,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::None do
             'authentication_none_authenticator' => HrrRbSsh::Authentication::Authenticator.new { |context| context.verify "username" }
           }
         }
-        let(:none_method){ described_class.new transport, options, variables }
+        let(:none_method){ described_class.new transport, options, variables, authentication_methods }
 
         it "returns true" do
           expect( none_method.authenticate userauth_request_message ).to be true
@@ -73,7 +74,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::None do
             'authentication_none_authenticator' => HrrRbSsh::Authentication::Authenticator.new { |context| context.verify "mismatch" }
           }
         }
-        let(:none_method){ described_class.new transport, options, variables }
+        let(:none_method){ described_class.new transport, options, variables, authentication_methods }
 
         it "returns false" do
           expect( none_method.authenticate userauth_request_message ).to be false

--- a/spec/hrr_rb_ssh/authentication/method/password/context_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/password/context_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password::Context do
   let(:context_username){ 'username' }
   let(:context_password){ 'password' }
   let(:context_variables){ {} }
-  let(:context){ described_class.new context_username, context_password, context_variables }
+  let(:context_authentication_methods){ [] }
+  let(:context){ described_class.new context_username, context_password, context_variables, context_authentication_methods }
 
   describe ".new" do
     it "takes two arguments: username and password" do
@@ -16,7 +17,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password::Context do
   describe "#username" do
     let(:context_username){ "username" }
     let(:context_password){ "password" }
-    let(:context){ described_class.new context_username, context_password, context_variables }
+    let(:context){ described_class.new context_username, context_password, context_variables, context_authentication_methods }
 
     it "returns \"username\"" do
       expect( context.username ).to eq context_username
@@ -26,7 +27,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password::Context do
   describe "#password" do
     let(:context_username){ "username" }
     let(:context_password){ "password" }
-    let(:context){ described_class.new context_username, context_password, context_variables }
+    let(:context){ described_class.new context_username, context_password, context_variables, context_authentication_methods }
 
     it "returns \"password\"" do
       expect( context.password ).to eq context_password
@@ -45,10 +46,16 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password::Context do
     end
   end
 
+  describe "#authentication_methods" do
+    it "returns \"authentication_methods\"" do
+      expect( context.authentication_methods ).to be context_authentication_methods
+    end
+  end
+
   describe "#verify" do
     let(:context_username){ "username" }
     let(:context_password){ "password" }
-    let(:context){ described_class.new context_username, context_password, context_variables }
+    let(:context){ described_class.new context_username, context_password, context_variables, context_authentication_methods }
     
     context "with \"username\" and \"password\"" do
       let(:username){ "username" }

--- a/spec/hrr_rb_ssh/authentication/method/password_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/password_spec.rb
@@ -18,13 +18,14 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password do
   end           
 
   describe ".new" do
-    it "takes three arguments: transport, options, and variables" do
-      expect { described_class.new(transport, {}, {}) }.not_to raise_error
+    it "takes three arguments: transport, options, variables, and authentication_methods" do
+      expect { described_class.new(transport, {}, {}, []) }.not_to raise_error
     end     
   end
 
   describe "#authenticate" do
     let(:variables){ {} }
+    let(:authentication_methods){ [] }
     let(:userauth_request_message){
       {
         :'user name'          => "username",
@@ -34,7 +35,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password do
 
     context "when options does not have 'authentication_password_authenticator'" do
       let(:options){ {} }
-      let(:password_method){ described_class.new transport, options, variables }
+      let(:password_method){ described_class.new transport, options, variables, authentication_methods }
 
       it "returns false" do
         expect( password_method.authenticate userauth_request_message ).to be false
@@ -47,7 +48,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password do
           'authentication_password_authenticator' => HrrRbSsh::Authentication::Authenticator.new { true }
         }
       }
-      let(:password_method){ described_class.new transport, options, variables }
+      let(:password_method){ described_class.new transport, options, variables, authentication_methods }
 
       it "returns true" do
         expect( password_method.authenticate userauth_request_message ).to be true
@@ -61,7 +62,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password do
             'authentication_password_authenticator' => HrrRbSsh::Authentication::Authenticator.new { |context| context.verify "username", "password" }
           }
         }
-        let(:password_method){ described_class.new transport, options, variables }
+        let(:password_method){ described_class.new transport, options, variables, authentication_methods }
 
         it "returns true" do
           expect( password_method.authenticate userauth_request_message ).to be true
@@ -74,7 +75,7 @@ RSpec.describe HrrRbSsh::Authentication::Method::Password do
             'authentication_password_authenticator' => HrrRbSsh::Authentication::Authenticator.new { |context| context.verify "mismatch", "mismatch" }
           }
         }
-        let(:password_method){ described_class.new transport, options, variables }
+        let(:password_method){ described_class.new transport, options, variables, authentication_methods }
 
         it "returns false" do
           expect( password_method.authenticate userauth_request_message ).to be false

--- a/spec/hrr_rb_ssh/authentication/method/publickey/context_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/publickey/context_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe HrrRbSsh::Authentication::Method::Publickey::Context do
     }
   }
   let(:context_variables){ {} }
-  let(:context){ described_class.new username, algorithm, session_id, message, context_variables }
+  let(:context_authentication_methods){ [] }
+  let(:context){ described_class.new username, algorithm, session_id, message, context_variables, context_authentication_methods }
 
   describe ".new" do
     it "takes four arguments: username, algorithm, session_id, message" do
@@ -91,6 +92,12 @@ RSpec.describe HrrRbSsh::Authentication::Method::Publickey::Context do
   describe "#vars" do
     it "returns \"variables\"" do
       expect( context.vars ).to be context_variables
+    end
+  end
+
+  describe "#authentication_methods" do
+    it "returns \"authentication_methods\"" do
+      expect( context.authentication_methods ).to be context_authentication_methods
     end
   end
 

--- a/spec/hrr_rb_ssh/authentication/method/publickey_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/publickey_spec.rb
@@ -26,11 +26,12 @@ RSpec.describe HrrRbSsh::Authentication::Method::Publickey do
     }
   }
   let(:variables){ {} }
-  let(:publickey){ described_class.new(transport, options, variables) }
+  let(:authentication_methods){ [] }
+  let(:publickey){ described_class.new(transport, options, variables, authentication_methods) }
 
   describe ".new" do
-    it "takes three arguments: transport, options, and variables" do
-      expect { described_class.new(transport, {}, {}) }.not_to raise_error
+    it "takes three arguments: transport, options, variables, and authentication_methods" do
+      expect { described_class.new(transport, {}, {}, []) }.not_to raise_error
     end     
 
     it "stores @session_id" do


### PR DESCRIPTION
This PR also addresses Issue #10.

A `context` variable in an authenticator gives an access to remaining authentication methods that can continue. In this strategy, an implementer is able to control the order of authentication methods and to control which authentication methods are used for the user.

The below is an example. It is expected that any user must be verified by publickey and then another authentication is requested for the user accordingly.

```ruby
auth_preferred_authentication_methods = ['none']
auth_none = HrrRbSsh::Authentication::Authenticator.new{ |context|
  context.authentication_methods.push 'publickey'
  HrrRbSsh::Authentication::PARTIAL_SUCCESS
}
auth_publickey = HrrRbSsh::Authentication::Authenticator.new{ |context|
  if some_verification(context)
    case context.username
    when 'user1'
      context.authentiation_methods.push 'keyboard-interactive'
      HrrRbSsh::Authentication::PARTIAL_SUCCESS
    else
      false
    end
  else
    false
  end
}
auth_keyboard_interactive = HrrRbSsh::Authentication::Authenticator.new{ |context|
  if some_verification(context)
    true # or HrrRbSsh::Authentication::PARTIAL_SUCCESS; both will accept the user because remaining authentication method is only 'keyboard-interactive' in this case
  else
    false
  end
}
options['authentication_preferred_authentication_methods'] = auth_preferred_authentication_methods
options['authentication_none_authenticator'] = auth_none
options['authentication_publickey_authenticator'] = auth_publickey
options['authentication_keyboard_interactive_authenticator'] = auth_keyboard_interactive
```