### PR TITLE
update not to get error with frozen-string-literal enabled

### DIFF
--- a/lib/hrr_rb_ssh/transport.rb
+++ b/lib/hrr_rb_ssh/transport.rb
@@ -68,8 +68,8 @@ module HrrRbSsh
       @sender_monitor   = Monitor.new
       @receiver_monitor = Monitor.new
 
-      @local_version  = @options.delete('local_version') || "SSH-2.0-HrrRbSsh-#{VERSION}".force_encoding(Encoding::ASCII_8BIT)
-      @remote_version = "".force_encoding(Encoding::ASCII_8BIT)
+      @local_version  = (@options.delete('local_version') || "SSH-2.0-HrrRbSsh-#{VERSION}").encode(Encoding::ASCII_8BIT)
+      @remote_version = nil
 
       @incoming_sequence_number = SequenceNumber.new
       @outgoing_sequence_number = SequenceNumber.new
@@ -310,7 +310,7 @@ module HrrRbSsh
         str_io.write @io.read(1)
         if str_io.string[-2..-1] == "#{CR}#{LF}"
           if str_io.string[0..3] == "SSH-"
-            @remote_version = str_io.string[0..-3]
+            @remote_version = str_io.string[0..-3].encode(Encoding::ASCII_8BIT)
             log_info { "received remote version string: #{@remote_version}" }
             break
           else

--- a/spec/hrr_rb_ssh/connection_spec.rb
+++ b/spec/hrr_rb_ssh/connection_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe HrrRbSsh::Connection do
     let(:authentication){ HrrRbSsh::Authentication.new transport, mode }
     let(:options){ Hash.new }
     let(:connection){ described_class.new authentication, mode, options, logger: nil }
-    let(:connection_loop_thread){ 'connection_loop_thread' }
+    let(:connection_loop_thread){ double("connection_loop_thread") }
 
     it "calls authentication.start and connection_loop_thread" do
       expect(authentication).to receive(:start).with(no_args).once
@@ -133,7 +133,7 @@ RSpec.describe HrrRbSsh::Connection do
     let(:mode){ HrrRbSsh::Mode::SERVER }
     let(:transport){ HrrRbSsh::Transport.new io, mode }
     let(:authentication){ HrrRbSsh::Authentication.new transport, mode }
-    let(:connection_loop_thread){ 'connection_loop_thread' }
+    let(:connection_loop_thread){ double("connection_loop_thread") }
     let(:options){ Hash.new }
     let(:connection){ described_class.new authentication, mode, options, logger: nil }
     let(:channel0){ double("channel0") }


### PR DESCRIPTION
Now the library can be run with --enable-frozen-string-literal option.