### PR TITLE
fix data_type/string and data_type/name_list to support multibytes charactors

### DIFF
--- a/lib/hrr_rb_ssh/data_type/name_list.rb
+++ b/lib/hrr_rb_ssh/data_type/name_list.rb
@@ -19,10 +19,10 @@ module HrrRbSsh
           raise ArgumentError, "must be with all elements of String, but got #{arg.inspect}"
         end
         joined_arg = arg.join(',')
-        if joined_arg.length > 0xffff_ffff
-          raise ArgumentError, "must be shorter than or equal to #{0xffff_ffff}, but got length #{joined_arg.length}"
+        if joined_arg.bytesize > 0xffff_ffff
+          raise ArgumentError, "must be shorter than or equal to #{0xffff_ffff}, but got length #{joined_arg.bytesize}"
         end
-        [joined_arg.length, joined_arg].pack("Na*")
+        [joined_arg.bytesize, joined_arg].pack("Na*")
       end
 
       # Convert binary string into a comma-separated list of names.

--- a/lib/hrr_rb_ssh/data_type/string.rb
+++ b/lib/hrr_rb_ssh/data_type/string.rb
@@ -15,10 +15,10 @@ module HrrRbSsh
         unless arg.kind_of? ::String
           raise ArgumentError, "must be a kind of String, but got #{arg.inspect}"
         end
-        if arg.length > 0xffff_ffff
-          raise ArgumentError, "must be shorter than or equal to #{0xffff_ffff}, but got length #{arg.length}"
+        if arg.bytesize > 0xffff_ffff
+          raise ArgumentError, "must be shorter than or equal to #{0xffff_ffff}, but got length #{arg.bytesize}"
         end
-        [arg.length, arg].pack("Na*")
+        [arg.bytesize, arg].pack("Na*")
       end
 
       # Convert binary string into Ruby's string value.

--- a/spec/hrr_rb_ssh/data_type/name_list_spec.rb
+++ b/spec/hrr_rb_ssh/data_type/name_list_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe HrrRbSsh::DataType::NameList do
           expect(array_mock).to receive(:kind_of?).with(Array).and_return(true).once
           expect(array_mock).to receive(:all?).with(any_args).and_return(true).once
           expect(array_mock).to receive(:join).with(',').and_return(string_mock).once
-          expect(string_mock).to receive(:length).with(no_args).and_return(0xffff_ffff + 1).twice
+          expect(string_mock).to receive(:bytesize).with(no_args).and_return(0xffff_ffff + 1).twice
 
           expect { HrrRbSsh::DataType::NameList.encode array_mock }.to raise_error ArgumentError
         end

--- a/spec/hrr_rb_ssh/data_type/string_spec.rb
+++ b/spec/hrr_rb_ssh/data_type/string_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe HrrRbSsh::DataType::String do
         str_mock = double('str mock with length (0xffff_ffff + 1)')
 
         expect(str_mock).to receive(:kind_of?).with(::String).and_return(true).once
-        expect(str_mock).to receive(:length).with(no_args).and_return(0xffff_ffff + 1).twice
+        expect(str_mock).to receive(:bytesize).with(no_args).and_return(0xffff_ffff + 1).twice
 
         expect { HrrRbSsh::DataType::String.encode str_mock }.to raise_error ArgumentError
       end


### PR DESCRIPTION
When DataType::String.encode and DataType::NameList takes multi-bytes encoded string, it calculates the length not in bytes. This PR fixes that.