### PR TITLE
Fix ssh-dss signature verification with OpenSSL 3+

### DIFF
--- a/lib/hrr_rb_ssh/algorithm/publickey/ssh_dss.rb
+++ b/lib/hrr_rb_ssh/algorithm/publickey/ssh_dss.rb
@@ -56,8 +56,8 @@ module HrrRbSsh
           hash = OpenSSL::Digest.digest(self.class::DIGEST, signature_blob)
           sign_der = @publickey.syssign(hash)
           sign_asn1 = OpenSSL::ASN1.decode sign_der
-          sign_r = sign_asn1.value[0].value.to_s(2).rjust(20, ["00"].pack("H"))
-          sign_s = sign_asn1.value[1].value.to_s(2).rjust(20, ["00"].pack("H"))
+          sign_r = sign_asn1.value[0].value.to_s(2).rjust(28, ["00"].pack("H"))
+          sign_s = sign_asn1.value[1].value.to_s(2).rjust(28, ["00"].pack("H"))
           signature_h = {
             :'public key algorithm name' => self.class::NAME,
             :'signature blob'            => (sign_r + sign_s),
@@ -67,8 +67,8 @@ module HrrRbSsh
 
         def verify signature, signature_blob
           signature_h = Signature.new(logger: logger).decode signature
-          sign_r = signature_h[:'signature blob'][ 0, 20]
-          sign_s = signature_h[:'signature blob'][20, 20]
+          sign_r = signature_h[:'signature blob'][ 0, 28]
+          sign_s = signature_h[:'signature blob'][28, 28]
           sign_asn1 = OpenSSL::ASN1::Sequence.new(
             [
               OpenSSL::ASN1::Integer.new(OpenSSL::BN.new(sign_r, 2)),

--- a/spec/hrr_rb_ssh/authentication/method/publickey/algorithm/ssh_dss_spec.rb
+++ b/spec/hrr_rb_ssh/authentication/method/publickey/algorithm/ssh_dss_spec.rb
@@ -146,8 +146,8 @@ yFHINL3X2CjZDKKLJ2Fl
       let(:hash){ OpenSSL::Digest.digest(digest, data) }
       let(:sign_der){ pkey.syssign(hash) }
       let(:sign_asn1){ OpenSSL::ASN1.decode(sign_der) }
-      let(:sign_r){ sign_asn1.value[0].value.to_s(2).rjust(20, ["00"].pack("H")) }
-      let(:sign_s){ sign_asn1.value[1].value.to_s(2).rjust(20, ["00"].pack("H")) }
+      let(:sign_r){ sign_asn1.value[0].value.to_s(2).rjust(28, ["00"].pack("H")) }
+      let(:sign_s){ sign_asn1.value[1].value.to_s(2).rjust(28, ["00"].pack("H")) }
       let(:signature_blob){ sign_r + sign_s }
       let(:signature){
         [
@@ -165,8 +165,8 @@ yFHINL3X2CjZDKKLJ2Fl
       let(:hash){ OpenSSL::Digest.digest(digest, data) }
       let(:sign_der){ pkey.syssign(hash) }
       let(:sign_asn1){ OpenSSL::ASN1.decode(sign_der) }
-      let(:sign_r){ sign_asn1.value[0].value.to_s(2).rjust(20, ["00"].pack("H")) }
-      let(:sign_s){ sign_asn1.value[1].value.to_s(2).rjust(20, ["00"].pack("H")) }
+      let(:sign_r){ sign_asn1.value[0].value.to_s(2).rjust(28, ["00"].pack("H")) }
+      let(:sign_s){ sign_asn1.value[1].value.to_s(2).rjust(28, ["00"].pack("H")) }
       let(:signature_blob){ sign_r + sign_s }
       let(:signature){
         [
@@ -184,8 +184,8 @@ yFHINL3X2CjZDKKLJ2Fl
       let(:hash){ OpenSSL::Digest.digest(digest, data) }
       let(:sign_der){ pkey.syssign(hash) }
       let(:sign_asn1){ OpenSSL::ASN1.decode(sign_der) }
-      let(:sign_r){ sign_asn1.value[0].value.to_s(2).rjust(20, ["00"].pack("H")) }
-      let(:sign_s){ sign_asn1.value[1].value.to_s(2).rjust(20, ["00"].pack("H")) }
+      let(:sign_r){ sign_asn1.value[0].value.to_s(2).rjust(28, ["00"].pack("H")) }
+      let(:sign_s){ sign_asn1.value[1].value.to_s(2).rjust(28, ["00"].pack("H")) }
       let(:signature_blob){ sign_r + sign_s }
       let(:incorrect_signature_blob){ "incorrect" + signature_blob }
       let(:signature){


### PR DESCRIPTION
The PR #34 shows a failling test on systems using OpenSSL 3.  By
tracking the code execution, we can see that after computing the DER
signature, it is decoded to ASN.1, and that both values in the ASN.1
message are handled separately as `sign_r` and `sign_s`, which are
padded to 20 chars by "\0".

On Debian 11 with OpenSSL 1.1.1n and Ruby 2.7.4p191, `sign_r` and
`sign_s` are 20 bytes long, while on Ubuntu 22 with OpenSSL 3.0.2 and
Ruby 3.0.2p107 they are 28 bytes long.

This is not an issue when building `signature_h` where we concatenate
`sign_r` and `sign_s` because right padding a 28 chars long string to 20
chars does not change it; but for verification we read `sign_r` and
`sign_s` from fixed position in `signature_h[:'signature blob']`.  As a
consquence, the read `sign_r` is truncated and the read `sign_s` is
mangled with the end of `sign_r` and the beginnig of the expected
`sign_s`.  Of course, the signature verification then fails.

Right-padding to 28 chars instead of 28 and adjusing the offsets
accordingly seems to verify as expected on all Ruby/OpenSSL versions.
